### PR TITLE
Change sample port number for the frontend app

### DIFF
--- a/Frontend/.env-example
+++ b/Frontend/.env-example
@@ -1,2 +1,2 @@
 REACT_APP_BASE_API_URL=http://localhost:5001
-PORT=5001
+PORT=6001


### PR DESCRIPTION
Previously the sample port number was 5001, which is exactly where the backend app runs by default, so if someone simply copied the .env-example to .env and ran the frontend app, the port would already be in use.