### PR TITLE
Remove NAT gateway from AWS (cost savings)

### DIFF
--- a/infrastructure/aws/aws.tf
+++ b/infrastructure/aws/aws.tf
@@ -111,18 +111,9 @@ resource "aws_internet_gateway" "internet-gateway" {
   }
 }
 
-resource "aws_eip" "nat-gateway-ip" {
-  vpc = true
-}
-
-resource "aws_nat_gateway" "nat-gateway" {
-  subnet_id = aws_subnet.public.id
-  allocation_id = aws_eip.nat-gateway-ip.id
-}
-
 # Routing table settings, we have 2 routing tables
 # 1. public -> have access directly to internet gateway
-# 2. private -> is routed to internet via NAT Gateway
+# 2. private -> have access directly to internet gateway too (to save cost on NAT)
 #
 # There is default table (set as main) without access to internet, only for local routes. Which is good default.
 resource "aws_route_table" "public-routes" {
@@ -143,7 +134,7 @@ resource "aws_route_table" "private-routes" {
 
   route {
     cidr_block = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat-gateway.id
+    gateway_id = aws_internet_gateway.internet-gateway.id
   }
 
   tags = {


### PR DESCRIPTION
Udelal sem analyzu ceny AWS a smazal jsem NAT gateway (je to sice staticky naklad, ale relativne velky oproti celkove cene, kterou se snazime dostat co nejniz).

Druha relativne draha polozka je ELB (elastic load balancer), ktery je take staticky naklad, ale momentalne 50% ceny. Nechavam ho tam, protoze tam v tehle architekture byt musi.

Zbytek mimo ceny za beh kontejneru jsou halerove polozky.