### PR TITLE
Extended BE timeout for hlidacstatu requests

### DIFF
--- a/NasiPolitici/Startup.cs
+++ b/NasiPolitici/Startup.cs
@@ -29,7 +29,13 @@ namespace HlidacStatu.NasiPolitici
                 config.BaseAddress = new Uri(Configuration.GetValue<string>("HlidacApiUrl"));
                 config.DefaultRequestHeaders.Authorization =
                     new AuthenticationHeaderValue("Token", Configuration.GetValue<string>("HlidacAuthenticationToken"));
-
+                
+                string hlidacHttpTimeoutConfig = Configuration.GetValue<string>("HlidacHttpTimeout");
+                
+                if (double.TryParse(hlidacHttpTimeoutConfig, out double hlidacHttpTimeout))
+                {
+                    config.Timeout = TimeSpan.FromMinutes(hlidacHttpTimeout);
+                }
             });
 
             services.AddHttpClient<INewsService, NewsService>(config =>

--- a/NasiPolitici/appsettings.json
+++ b/NasiPolitici/appsettings.json
@@ -10,6 +10,7 @@
   "AllowedHosts": "*",
 
   "HlidacApiUrl": "https://www.hlidacstatu.cz/api/v1/",
+  "HlidacHttpTimeout": 4,
 
   "CzFinApiUrl": "https://www.cz-fin.com/Api_V1/",
 


### PR DESCRIPTION
Added setting `HlidacHttpTimeout` to extend http timeout to Hlidac statu.