### PR TITLE
Console warn místo console error

### DIFF
--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -20,7 +20,7 @@ const App: React.FC = () => {
     const { REACT_APP_GTM_ID } = process.env
 
     if (REACT_APP_GTM_ID) init({ id: REACT_APP_GTM_ID })
-    else console.error('GTM id not set.')
+    else console.warn('GTM id not set.')
   }, [init])
 
   return (


### PR DESCRIPTION
Jde jen o malou změnu, aby teď neskákal na produkci zbytečně error, warn je podle mně dostačující..